### PR TITLE
Add config file support

### DIFF
--- a/lib/asciidoctor/acme/converter.rb
+++ b/lib/asciidoctor/acme/converter.rb
@@ -138,6 +138,26 @@ module Asciidoctor
         return
       end
 
+      def html_extract_attributes(node)
+        configured_attributes = Metanorma::Acme.configuration.html_extract_attributes
+        {
+          script: configured_attributes["script"] || node.attr("script"),
+          bodyfont: configured_attributes["body-font"] || node.attr("body-font"),
+          headerfont: configured_attributes["header-font"] || node.attr("header-font"),
+          monospacefont: configured_attributes["monospace-font"] || node.attr("monospace-font"),
+          i18nyaml: configured_attributes["i18nyaml"] || node.attr("i18nyaml"),
+          scope: configured_attributes["scope"] || node.attr("scope"),
+          htmlstylesheet: configured_attributes["htmlstylesheet"] || node.attr("htmlstylesheet"),
+          htmlcoverpage: configured_attributes["htmlcoverpage"] || node.attr("htmlcoverpage"),
+          htmlintropage: configured_attributes["htmlintropage"] || node.attr("htmlintropage"),
+          scripts: configured_attributes["scripts"] || node.attr("scripts"),
+          scripts_pdf: configured_attributes["scripts-pdf"] || node.attr("scripts-pdf"),
+          datauriimage: configured_attributes["data-uri-image"] || node.attr("data-uri-image"),
+          htmltoclevels: configured_attributes["htmltoclevels"] || node.attr("htmltoclevels") || node.attr("toclevels"),
+          doctoclevels: configured_attributes["doctoclevels"] || node.attr("doctoclevels") || node.attr("toclevels"),
+        }
+      end
+
       def html_converter(node)
         IsoDoc::Acme::HtmlConvert.new(html_extract_attributes(node))
       end

--- a/lib/metanorma/acme.rb
+++ b/lib/metanorma/acme.rb
@@ -1,12 +1,55 @@
 require "metanorma/acme/processor"
 require "metanorma/acme/version"
+require 'forwardable'
 
 module Metanorma
   module Acme
-
     ORGANIZATION_NAME_SHORT = "Acme"
     ORGANIZATION_NAME_LONG = "Acme Corp."
     DOCUMENT_NAMESPACE = "https://open.ribose.com/standards/acme"
 
+    class Configuration
+      CONFIG_ATTRS = %i[
+        organization_name_short
+        organization_name_long
+        document_namespace
+        html_extract_attributes
+      ].freeze
+
+      attr_accessor(*CONFIG_ATTRS)
+
+      def initialize(*args)
+        super
+        self.organization_name_short ||= ORGANIZATION_NAME_SHORT
+        self.organization_name_long ||= ORGANIZATION_NAME_LONG
+        self.document_namespace ||= DOCUMENT_NAMESPACE
+        self.html_extract_attributes ||= {}
+      end
+
+      def html_extract_attributes=(attributes)
+        unless attributes.is_a?(Hash) && (attributes.length.zero? || attributes.keys.all? { |name| name.is_a?(String) })
+          raise(ArgumentError, "html_extract_attributes requires a hash with string keys")
+        end
+
+        self.instance_variable_set(:@html_extract_attributes, attributes)
+      end
+    end
+
+    class << self
+      extend Forwardable
+
+      attr_accessor :configuration
+
+      Configuration::CONFIG_ATTRS.each do |attr_name|
+        def_delegator :@configuration, attr_name
+      end
+
+      def configure
+        self.configuration ||= Configuration.new
+        yield(configuration)
+      end
+    end
+
+    configure {}
   end
 end

--- a/spec/metanorma/acme_spec.rb
+++ b/spec/metanorma/acme_spec.rb
@@ -4,4 +4,51 @@ RSpec.describe Metanorma::Acme do
   it "has a version number" do
     expect(Metanorma::Acme::VERSION).not_to be nil
   end
+
+  describe '#configuration' do
+    it 'has `configuration` attribute accessable' do
+      expect(Metanorma::Acme.configuration).to be_instance_of(Metanorma::Acme::Configuration)
+    end
+
+    context 'default attributes' do
+      subject(:config) { Metanorma::Acme.configuration }
+      let(:default_organization_name_short) { "Acme" }
+      let(:default_organization_name_long) { "Acme Corp." }
+      let(:default_document_namespace) { "https://open.ribose.com/standards/acme" }
+      let(:default_html_extract_attributes) { {} }
+
+      it 'sets default atrributes' do
+        expect(config.organization_name_short).to eq(default_organization_name_short)
+        expect(config.organization_name_long).to eq(default_organization_name_long)
+        expect(config.document_namespace).to eq(default_document_namespace)
+        expect(config.html_extract_attributes).to eq(default_html_extract_attributes)
+      end
+    end
+
+    context 'attribute setters' do
+      subject(:config) { Metanorma::Acme.configuration }
+      let(:organization_name_short) { "Test" }
+      let(:organization_name_long) { "Test Corp." }
+      let(:document_namespace) { "https://example.com/" }
+      let(:html_extract_attributes) do
+        {
+          'one' => 'sting',
+          'two' => 'number'
+        }
+      end
+
+      it 'sets atrributes' do
+        Metanorma::Acme.configure do |config|
+          config.organization_name_short = organization_name_short
+          config.organization_name_long = organization_name_long
+          config.document_namespace = document_namespace
+          config.html_extract_attributes = html_extract_attributes
+        end
+        expect(config.organization_name_short).to eq(organization_name_short)
+        expect(config.organization_name_long).to eq(organization_name_long)
+        expect(config.document_namespace).to eq(document_namespace)
+        expect(config.html_extract_attributes).to eq(html_extract_attributes)
+      end
+    end
+  end
 end


### PR DESCRIPTION
Prerequirement for metanorma/metanorma-vsd#4. 
Add configuration class fro Acme module, and allow passing  custom attributes to Asciidoctor#Acme#Converter#html_extract_attributes and  Asciidoctor#Acme#Converter#doc_extract_attributes