### PR TITLE
Document attribute to point config file

### DIFF
--- a/lib/asciidoctor/acme/converter.rb
+++ b/lib/asciidoctor/acme/converter.rb
@@ -70,10 +70,6 @@ module Asciidoctor
         end
       end
 
-      def title_validate(root)
-        nil
-      end
-
       def makexml(node)
         root_tag = configuration.xml_root_tag || 'acme-standard'
         result = ["<?xml version='1.0' encoding='UTF-8'?>\n<#{root_tag}>"]
@@ -97,7 +93,12 @@ module Asciidoctor
         d
       end
 
+      def read_config_file(path_to_config_file)
+        Metanorma::Acme.configuration.set_default_values_from_yaml_file(path_to_config_file)
+      end
+
       def document(node)
+        read_config_file(node.attr("customize")) if node.attr("customize")
         init(node)
         ret1 = makexml(node)
         ret = ret1.to_xml(indent: 2)
@@ -131,17 +132,15 @@ module Asciidoctor
         end
       end
 
-      def style(n, t)
-        return
-      end
+      def blank_method(*args); end
 
       def html_converter(node)
         IsoDoc::Acme::HtmlConvert.new(html_extract_attributes(node))
       end
 
-      def pdf_converter(node)
-        IsoDoc::Acme::PdfConvert.new(html_extract_attributes(node))
-      end
+      alias_method :pdf_converter, :html_converter
+      alias_method :style, :blank_method
+      alias_method :title_validate, :blank_method
 
       def word_converter(node)
         IsoDoc::Acme::WordConvert.new(doc_extract_attributes(node))

--- a/lib/metanorma/acme.rb
+++ b/lib/metanorma/acme.rb
@@ -38,17 +38,15 @@ module Metanorma
 
       def initialize(*args)
         super
-        set_default_values_from_yaml_file
+        # Try to set config values from yaml file in current directory
+        set_default_values_from_yaml_file(YAML_CONFIG_FILE) if File.file?(YAML_CONFIG_FILE)
         self.organization_name_short ||= ORGANIZATION_NAME_SHORT
         self.organization_name_long ||= ORGANIZATION_NAME_LONG
         self.document_namespace ||= DOCUMENT_NAMESPACE
       end
 
-      # Try to set config values from yaml file in current directory
-      def set_default_values_from_yaml_file
-        return unless File.file?(YAML_CONFIG_FILE)
-
-        default_config_options = YAML.load(File.read(YAML_CONFIG_FILE))
+      def set_default_values_from_yaml_file(config_file)
+        default_config_options = YAML.load(File.read(config_file))
         CONFIG_ATTRS.each do |attr_name|
           instance_variable_set("@#{attr_name}", default_config_options[attr_name.to_s])
         end

--- a/spec/asciidoctor/base_spec.rb
+++ b/spec/asciidoctor/base_spec.rb
@@ -207,6 +207,51 @@ RSpec.describe Asciidoctor::Acme do
     expect(html).to match(%r[h1, h2, h3, h4, h5, h6 \{[^}]+font-family: "Overpass", sans-serif;]m)
   end
 
+  context 'customize directive' do
+    subject(:config) { Metanorma::Acme.configuration }
+    let(:config_file) { Tempfile.new('my_custom_config_file.yml') }
+    let(:organization_name_short) { 'Test' }
+    let(:organization_name_long) { 'Test Corp.' }
+    let(:document_namespace) { 'https://example.com/' }
+    let(:input) do
+      <<~"INPUT"
+        = Document title
+        Author
+        :customize: #{config_file.path}
+        :docfile: test.adoc
+        :novalid:
+      INPUT
+    end
+    let(:yaml_content) do
+      {
+        'organization_name_short' => organization_name_short,
+        'organization_name_long' => organization_name_long,
+        'document_namespace' => document_namespace
+      }
+    end
+
+    before do
+      FileUtils.rm_f "test.html"
+      config_file.tap { |file| file.puts(yaml_content.to_yaml) }.close
+      Metanorma::Acme.configure do |config|
+        config.organization_name_short = ''
+        config.organization_name_long = ''
+        config.document_namespace = ''
+      end
+    end
+
+    after do
+      FileUtils.rm_f "test.html"
+    end
+
+    it 'recognizes `customize` option and uses supplied file as the config file' do
+      expect { Asciidoctor.convert(input, backend: :acme, header_footer: true) }
+        .to(change {
+          [config.organization_name_short, config.organization_name_long, config.document_namespace]
+          }.from(['','','']).to([organization_name_short, organization_name_long, document_namespace]))
+    end
+  end
+
   it "uses Chinese fonts" do
     input = <<~"INPUT"
       = Document title


### PR DESCRIPTION
#19 
Support for `customize` option in adoc file - user can provide path to config file in this option.