### PR TITLE
Strip @boilerplate=true from bibdata_hash; refresh on resolution

### DIFF
--- a/Gemfile.devel
+++ b/Gemfile.devel
@@ -1,0 +1,3 @@
+gem "metanorma-core", git: "https://github.com/metanorma/metanorma-core", branch: "fix/issue-558"
+gem "metanorma-standoc", git: "https://github.com/metanorma/metanorma-standoc", branch: "fix/issue-558"
+gem "html2doc", git: "https://github.com/metanorma/html2doc", branch: "main"

--- a/lib/metanorma/generic/cleanup.rb
+++ b/lib/metanorma/generic/cleanup.rb
@@ -24,11 +24,36 @@ module Metanorma
         b = xmldoc.at("//bibdata") || xmldoc.at("//xmlns:bibdata") or return nil
         stripped = Nokogiri::XML(b.to_xml)
         stripped.remove_namespaces!
+        # Drop @boilerplate="true" docidentifiers before handing the
+        # bibdata to Relaton::Cli.parse_xml: their content is an
+        # unresolved Liquid template, and recent relaton-iho /
+        # relaton-cc / etc. eagerly call pubid in their docidentifier
+        # content= setter, which crashes on raw Liquid syntax. The
+        # template variables for substitution come from other bibdata
+        # fields (seriesabbr, docnumeric, …), not from the
+        # docidentifier itself, so dropping it here does not affect
+        # what we feed back into isodoc.meta. Substitution still runs
+        # on the original xmldoc via standoc's
+        # docidentifier_boilerplate_isodoc; afterwards
+        # refresh_isodoc_bibdata re-calls bibdata_hash to seed
+        # isodoc.meta with the resolved docidentifier.
+        # See https://github.com/metanorma/metanorma/issues/558.
+        stripped.xpath("//docidentifier[@boilerplate = 'true']").each(&:remove)
         bib = BibdataConfig.from_xml(
           "<metanorma>#{stripped.root.to_xml}</metanorma>",
         ).bibdata or return nil
         YAML.safe_load(bib.to_yaml, permitted_classes: [Date, Symbol],
                                     symbolize_names: true)
+      end
+
+      # Override standoc's hook: in addition to re-running
+      # isodoc_bibdata_parse, refresh conv.meta[:bibdata] with the
+      # bibdata_hash now that docidentifiers have been substituted, so
+      # downstream consumers (boilerplate Liquid expansion, coverpage
+      # interpolation, etc.) see the resolved values.
+      def refresh_isodoc_bibdata(xmldoc, conv)
+        super
+        conv.meta.set(:bibdata, bibdata_hash(xmldoc))
       end
 
       def boilerplate_file(xmldoc)

--- a/metanorma-generic.gemspec
+++ b/metanorma-generic.gemspec
@@ -40,6 +40,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "sassc-embedded", "~> 1"
   spec.add_development_dependency "simplecov", "~> 0.15"
   spec.add_development_dependency "timecop", "~> 0.9"
-  spec.add_development_dependency "canon"
+  spec.add_development_dependency "canon", "= 0.2.3"
   spec.add_development_dependency "metanorma"
 end


### PR DESCRIPTION
Stop unresolved Liquid templates in `<docidentifier @boilerplate="true">` from reaching Relaton/pubid via `bibdata_hash`. Two-pass: strip on the early seed call, refresh `conv.meta[:bibdata]` after standoc has substituted the templates.

See https://github.com/metanorma/metanorma/issues/558 for diagnosis and per-gem changes.

Depends on: metanorma/metanorma-standoc#1178, metanorma/metanorma-core#3
